### PR TITLE
chore(workflow): use environment variables

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,7 +2,8 @@ name: Check
 
 on:
   push:
-  pull_request:
+    branches:
+      - 'master'
 
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ on:
 permissions:
   contents: write
 
+env:
+  APP_ENV: prod
+  LOG_LEVE: error
+  DOMAIN: ${{ secrets.DOMAIN }}
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,10 @@ permissions:
 
 env:
   APP_ENV: prod
-  LOG_LEVE: error
+  LOG_LEVEL: error
+  PORT: 3000
+  READ_BUFFER_SIZE: 0
+  WRITE_BUFFER_SIZE: 0
   DOMAIN: ${{ secrets.DOMAIN }}
 
 jobs:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,10 +10,10 @@ builds:
   - main: ./main/squirrel
     id: squirrel
     binary: squirrel
-    env:
-      - CGO_ENABLED=0
-      - LOG_LEVEL=error
-      - APP_ENV=prod
+    ldflags:
+      - -X github.com/omarahm3/squirrel/client.domain={{ .Env.DOMAIN }}
+      - -X github.com/omarahm3/squirrel/client.loglevel={{ .Env.LOG_LEVEL }}
+      - -X github.com/omarahm3/squirrel/client.env={{ .Env.APP_ENV }}
     goos:
       - linux
       - windows
@@ -25,11 +25,13 @@ builds:
   - main: ./main/squirreld
     id: squirreld
     binary: squirreld
-    env:
-      - CGO_ENABLED=0
-      - LOG_LEVEL=debug
-      - APP_ENV=dev
-      - PORT=8080
+    ldflags:
+      - -X github.com/omarahm3/squirrel/server.domain={{ .Env.DOMAIN }}
+      - -X github.com/omarahm3/squirrel/server.loglevel={{ .Env.LOG_LEVEL }}
+      - -X github.com/omarahm3/squirrel/server.env={{ .Env.APP_ENV }}
+      - -X github.com/omarahm3/squirrel/server.port={{ .Env.PORT }}
+      - -X github.com/omarahm3/squirrel/server.readBufferSize={{ .Env.READ_BUFFER_SIZE }}
+      - -X github.com/omarahm3/squirrel/server.writeBufferSize={{ .Env.WRITE_BUFFER_SIZE }}
     goos:
       - linux
     goarch:

--- a/client/options.go
+++ b/client/options.go
@@ -21,6 +21,12 @@ const (
 	DEFAULT_LOG_LEVEL   = "error"
 )
 
+var (
+  env      string
+  domain   string
+  loglevel string
+)
+
 func fprintf(format string, a ...interface{}) {
 	fmt.Fprintf(os.Stderr, format, a...)
 }
@@ -33,15 +39,9 @@ func InitOptions() *ClientOptions {
 		flag.PrintDefaults()
 	}
 
-	var (
-		env      string = utils.GetEnvVariable("APP_ENV")
-		domain   string = utils.GetEnvVariable("DOMAIN")
-		loglevel string = utils.GetEnvVariable("LOG_LEVEL")
-	)
-
-	flag.StringVar(&env, "env", utils.WinningDefault(utils.GetEnvVariable("APP_ENV"), DEFAULT_ENVIRONMENT), "Client environment (prod|dev)")
-	flag.StringVar(&domain, "domain", utils.WinningDefault(utils.GetEnvVariable("DOMAIN"), DEFAULT_DOMAIN), "Server domain")
-	flag.StringVar(&loglevel, "log", utils.WinningDefault(utils.GetEnvVariable("LOG_LEVEL"), DEFAULT_LOG_LEVEL), "Log level")
+	flag.StringVar(&env, "env", utils.WinningDefault(utils.GetEnvVariable("APP_ENV"), env, DEFAULT_ENVIRONMENT), "Client environment (prod|dev)")
+	flag.StringVar(&domain, "domain", utils.WinningDefault(utils.GetEnvVariable("DOMAIN"), domain, DEFAULT_DOMAIN), "Server domain")
+	flag.StringVar(&loglevel, "log", utils.WinningDefault(utils.GetEnvVariable("LOG_LEVEL"), loglevel, DEFAULT_LOG_LEVEL), "Log level")
 	flag.Parse()
 
 	return &ClientOptions{

--- a/client/options.go
+++ b/client/options.go
@@ -22,9 +22,9 @@ const (
 )
 
 var (
-  env      string
-  domain   string
-  loglevel string
+	env      string
+	domain   string
+	loglevel string
 )
 
 func fprintf(format string, a ...interface{}) {

--- a/server/main.go
+++ b/server/main.go
@@ -46,15 +46,15 @@ func wsHandler(hub *Hub, r *http.Request, w http.ResponseWriter) {
 }
 
 func printOptions() {
-  zap.S().Warnw(
-    "Server started with these options",
-    "Env", options.Env,
-    "Domain", options.Domain,
-    "Port", options.Port,
-    "Log Level", options.LogLevel.String(),
-    "Read Buffer Size", options.ReadBufferSize,
-    "Write Buffer Size", options.WriteBufferSize,
-  )
+	zap.S().Warnw(
+		"Server started with these options",
+		"Env", options.Env,
+		"Domain", options.Domain,
+		"Port", options.Port,
+		"Log Level", options.LogLevel.String(),
+		"Read Buffer Size", options.ReadBufferSize,
+		"Write Buffer Size", options.WriteBufferSize,
+	)
 }
 
 func Main() {
@@ -70,7 +70,7 @@ func Main() {
 		LogFileName: ".server.squirrel.log",
 	})
 
-  printOptions()
+	printOptions()
 
 	// Sync both loggers since they're all used
 	defer func() {

--- a/server/options.go
+++ b/server/options.go
@@ -28,12 +28,12 @@ const (
 )
 
 var (
-  env             string
-  domain          string
-  port            string
-  loglevel        string
-  readBufferSize  string
-  writeBufferSize string
+	env             string
+	domain          string
+	port            string
+	loglevel        string
+	readBufferSize  string
+	writeBufferSize string
 )
 
 func fprintf(format string, a ...interface{}) {

--- a/server/options.go
+++ b/server/options.go
@@ -27,6 +27,15 @@ const (
 	DEFAULT_WRITE_BUFFER_SIZE = "0"
 )
 
+var (
+  env             string
+  domain          string
+  port            string
+  loglevel        string
+  readBufferSize  string
+  writeBufferSize string
+)
+
 func fprintf(format string, a ...interface{}) {
 	fmt.Fprintf(os.Stderr, format, a...)
 }
@@ -40,21 +49,12 @@ func InitOptions() *ServerOptions {
 		fprintf("%s configures server run.\n", os.Args[0])
 	}
 
-	var (
-		env             string = utils.GetEnvVariable("APP_ENV")
-		domain          string = utils.GetEnvVariable("DOMAIN")
-		port            string = utils.GetEnvVariable("PORT")
-		loglevel        string = utils.GetEnvVariable("LOG_LEVEL")
-		readBufferSize  string = utils.GetEnvVariable("READ_BUFFER_SIZE")
-		writeBufferSize string = utils.GetEnvVariable("WRITE_BUFFER_SIZE")
-	)
-
-	flag.StringVar(&env, "env", utils.WinningDefault(utils.GetEnvVariable("APP_ENV"), DEFAULT_ENVIRONMENT), "Server environment (prod|dev)")
-	flag.StringVar(&domain, "domain", utils.WinningDefault(utils.GetEnvVariable("DOMAIN"), DEFAULT_DOMAIN), "Server domain")
-	flag.StringVar(&loglevel, "log", utils.WinningDefault(utils.GetEnvVariable("LOG_LEVEL"), DEFAULT_LOG_LEVEL), "Log level")
-	flag.StringVar(&port, "port", utils.WinningDefault(utils.GetEnvVariable("PORT"), DEFAULT_PORT), "Server port")
-	flag.StringVar(&readBufferSize, "read-buffer-size", utils.WinningDefault(utils.GetEnvVariable("READ_BUFFER_SIZE"), DEFAULT_READ_BUFFER_SIZE), "Websocket read buffer size")
-	flag.StringVar(&writeBufferSize, "write-buffer-size", utils.WinningDefault(utils.GetEnvVariable("WRITE_BUFFER_SIZE"), DEFAULT_WRITE_BUFFER_SIZE), "Websocket write buffer size")
+	flag.StringVar(&env, "env", utils.WinningDefault(utils.GetEnvVariable("APP_ENV"), env, DEFAULT_ENVIRONMENT), "Server environment (prod|dev)")
+	flag.StringVar(&domain, "domain", utils.WinningDefault(utils.GetEnvVariable("DOMAIN"), domain, DEFAULT_DOMAIN), "Server domain")
+	flag.StringVar(&loglevel, "log", utils.WinningDefault(utils.GetEnvVariable("LOG_LEVEL"), loglevel, DEFAULT_LOG_LEVEL), "Log level")
+	flag.StringVar(&port, "port", utils.WinningDefault(utils.GetEnvVariable("PORT"), port, DEFAULT_PORT), "Server port")
+	flag.StringVar(&readBufferSize, "read-buffer-size", utils.WinningDefault(utils.GetEnvVariable("READ_BUFFER_SIZE"), readBufferSize, DEFAULT_READ_BUFFER_SIZE), "Websocket read buffer size")
+	flag.StringVar(&writeBufferSize, "write-buffer-size", utils.WinningDefault(utils.GetEnvVariable("WRITE_BUFFER_SIZE"), writeBufferSize, DEFAULT_WRITE_BUFFER_SIZE), "Websocket write buffer size")
 	flag.Parse()
 
 	return &ServerOptions{

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -104,11 +104,11 @@ func GetLogLevelFromString(loglevel string) zapcore.Level {
 // And pick the first not empty one
 func WinningDefault(value string, values ...string) string {
 	if value == "" {
-    for _, alternative := range values {
-      if alternative != "" {
-        return alternative
-      }
-    }
+		for _, alternative := range values {
+			if alternative != "" {
+				return alternative
+			}
+		}
 	}
 	return value
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -100,9 +100,15 @@ func GetLogLevelFromString(loglevel string) zapcore.Level {
 	return level
 }
 
-func WinningDefault(value string, defaultValue string) string {
+// Function will pick first argument if it was not empty, or it will loop over the rest of the arguments
+// And pick the first not empty one
+func WinningDefault(value string, values ...string) string {
 	if value == "" {
-		return defaultValue
+    for _, alternative := range values {
+      if alternative != "" {
+        return alternative
+      }
+    }
 	}
 	return value
 }


### PR DESCRIPTION
Since we're depending mainly on flags & environment variables to pass configuration to both server & client, binaries were released in hardcodeed default values, that will require to always pass a flag while running either client or server.

I used `ldflags` to pass values from ENV variables to go linker, so that prebuilt binaries are ready for production use.

A really neat trick to find the import path of variables that are set on linking time, was to run this on the binary:

```
go tool nm ./squirrel | grep loglevel
```

that provided the full import path that we can use and pass to the `-X` flag

Ref: https://pkg.go.dev/cmd/link