### PR TITLE
Read peer events through CLI

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -15,8 +15,9 @@ type LogMessage struct {
 }
 
 type IdentityMessage struct {
-	PeerId string `json:"peerId"`
-	Local  bool   `json:"local"`
+	PeerId      string `json:"peerId"`
+	Broadcastor bool   `json:"broadcastor"`
+	Subscriber  bool   `json:"subscriber"`
 }
 
 type Message struct {

--- a/client/client.go
+++ b/client/client.go
@@ -16,7 +16,7 @@ type LogMessage struct {
 
 type IdentityMessage struct {
 	PeerId      string `json:"peerId"`
-	Broadcastor bool   `json:"broadcastor"`
+	Broadcaster bool   `json:"broadcaster"`
 	Subscriber  bool   `json:"subscriber"`
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -67,9 +67,9 @@ func HandleIncomingMessages(connection *websocket.Conn) {
 	for {
 		_, message, err := connection.ReadMessage()
 
-    if options.Listen && options.PeerId != "" {
-      fmt.Println(string(message))
-    }
+		if options.Listen && options.PeerId != "" {
+			fmt.Println(string(message))
+		}
 
 		if err != nil {
 			zap.L().Error("Error while reading incoming message", zap.Error(err))

--- a/client/client.go
+++ b/client/client.go
@@ -67,7 +67,9 @@ func HandleIncomingMessages(connection *websocket.Conn) {
 	for {
 		_, message, err := connection.ReadMessage()
 
-		zap.S().Debug("Incoming message: ", string(message))
+    if options.Listen && options.PeerId != "" {
+      fmt.Println(string(message))
+    }
 
 		if err != nil {
 			zap.L().Error("Error while reading incoming message", zap.Error(err))

--- a/client/main.go
+++ b/client/main.go
@@ -79,7 +79,7 @@ func SendIdentity(connection *websocket.Conn, clientId string) {
 		Event: "identity",
 		Payload: IdentityMessage{
 			PeerId:      "",
-			Broadcastor: true,
+			Broadcaster: true,
 			Subscriber:  false,
 		},
 	}

--- a/client/main.go
+++ b/client/main.go
@@ -78,7 +78,9 @@ func SendIdentity(connection *websocket.Conn, clientId string) {
 		Id:    clientId,
 		Event: "identity",
 		Payload: IdentityMessage{
-			Local: true,
+			PeerId:      "",
+			Broadcastor: true,
+			Subscriber:  false,
 		},
 	}
 

--- a/client/main.go
+++ b/client/main.go
@@ -74,13 +74,23 @@ func Main() {
 }
 
 func SendIdentity(connection *websocket.Conn, clientId string) {
+	var peerId string
+	var subscriber bool
+	broadcaster := true
+
+	if options.PeerId != "" {
+		peerId = options.PeerId
+		subscriber = true
+		broadcaster = false
+	}
+
 	message := Message{
 		Id:    clientId,
 		Event: "identity",
 		Payload: IdentityMessage{
-			PeerId:      "",
-			Broadcaster: true,
-			Subscriber:  false,
+			PeerId:      peerId,
+			Broadcaster: broadcaster,
+			Subscriber:  subscriber,
 		},
 	}
 

--- a/client/options.go
+++ b/client/options.go
@@ -14,6 +14,7 @@ type ClientOptions struct {
 	Domain   *utils.Domain
 	LogLevel zapcore.Level
 	PeerId   string
+	Listen   bool
 }
 
 const (
@@ -27,6 +28,7 @@ var (
 	domain   string
 	loglevel string
 	peer     string
+	listen   bool
 )
 
 func fprintf(format string, a ...interface{}) {
@@ -45,6 +47,7 @@ func InitOptions() *ClientOptions {
 	flag.StringVar(&domain, "domain", utils.WinningDefault(utils.GetEnvVariable("DOMAIN"), domain, DEFAULT_DOMAIN), "Server domain")
 	flag.StringVar(&loglevel, "log", utils.WinningDefault(utils.GetEnvVariable("LOG_LEVEL"), loglevel, DEFAULT_LOG_LEVEL), "Log level")
 	flag.StringVar(&peer, "peer", "", "Peer client ID")
+	flag.BoolVar(&listen, "listen", false, "Initiate in listen mode to listen to peer")
 	flag.Parse()
 
 	return &ClientOptions{
@@ -52,5 +55,6 @@ func InitOptions() *ClientOptions {
 		Domain:   utils.BuildDomain(domain, env),
 		LogLevel: utils.GetLogLevelFromString(loglevel),
 		PeerId:   peer,
+		Listen:   listen,
 	}
 }

--- a/client/options.go
+++ b/client/options.go
@@ -13,6 +13,7 @@ type ClientOptions struct {
 	Env      string
 	Domain   *utils.Domain
 	LogLevel zapcore.Level
+	PeerId   string
 }
 
 const (
@@ -25,6 +26,7 @@ var (
 	env      string
 	domain   string
 	loglevel string
+	peer     string
 )
 
 func fprintf(format string, a ...interface{}) {
@@ -42,11 +44,13 @@ func InitOptions() *ClientOptions {
 	flag.StringVar(&env, "env", utils.WinningDefault(utils.GetEnvVariable("APP_ENV"), env, DEFAULT_ENVIRONMENT), "Client environment (prod|dev)")
 	flag.StringVar(&domain, "domain", utils.WinningDefault(utils.GetEnvVariable("DOMAIN"), domain, DEFAULT_DOMAIN), "Server domain")
 	flag.StringVar(&loglevel, "log", utils.WinningDefault(utils.GetEnvVariable("LOG_LEVEL"), loglevel, DEFAULT_LOG_LEVEL), "Log level")
+	flag.StringVar(&peer, "peer", "", "Peer client ID")
 	flag.Parse()
 
 	return &ClientOptions{
 		Env:      env,
 		Domain:   utils.BuildDomain(domain, env),
 		LogLevel: utils.GetLogLevelFromString(loglevel),
+		PeerId:   peer,
 	}
 }

--- a/server/client.go
+++ b/server/client.go
@@ -52,6 +52,7 @@ func (client *Client) ReadPump() {
 	client.connection.SetReadLimit(options.MaxMessageSize)
 	client.connection.SetReadDeadline(readDeadline)
 	client.connection.SetPongHandler(func(_ string) error {
+		zap.S().Debug("Received Pong message")
 		client.connection.SetReadDeadline(time.Now().Add(PONG_WAIT))
 		return nil
 	})

--- a/server/hub.go
+++ b/server/hub.go
@@ -59,7 +59,8 @@ func (h *Hub) Run() {
 			zap.S().Infow("Adding client to hub",
 				"id", client.id,
 				"active", client.active,
-				"local", client.local,
+				"broadcaster", client.broadcaster,
+				"subscriber", client.subscriber,
 				"peerId", client.peerId)
 
 			h.clients[client.id] = client
@@ -84,10 +85,11 @@ func (h *Hub) Run() {
 
 			for _, client := range h.clients {
 				// Ignore any client and only accept client that has the link
-				if client.local || !client.active || client.peerId != message.clientId {
+				if client.broadcaster || !client.subscriber || !client.active || client.peerId != message.clientId {
 					zap.S().Debugw("Ignoring broadcasting message to this client",
 						"clientId", client.id,
-						"local", client.local,
+						"broadcaster", client.broadcaster,
+						"subscriber", client.subscriber,
 						"active", client.active)
 
 					continue
@@ -95,7 +97,8 @@ func (h *Hub) Run() {
 
 				zap.S().Debugw("Sending message to client",
 					"clientId", client.id,
-					"local", client.local,
+					"broadcaster", client.broadcaster,
+					"subscriber", client.subscriber,
 					"active", client.active)
 
 				select {

--- a/server/main.go
+++ b/server/main.go
@@ -30,11 +30,11 @@ func wsHandler(hub *Hub, r *http.Request, w http.ResponseWriter) {
 	zap.S().Info("Websocket connection was successful")
 
 	client := &Client{
-		id:         utils.GenerateUUID(),
-		connection: connection,
-		hub:        hub,
-		local:      false,
-		send:       make(chan []byte, 256),
+		id:          utils.GenerateUUID(),
+		connection:  connection,
+		hub:         hub,
+		broadcaster: false,
+		send:        make(chan []byte, 256),
 	}
 
 	zap.S().Infow("Initialized new client", "clientId", client.id)

--- a/server/message.go
+++ b/server/message.go
@@ -11,6 +11,7 @@ type LogMessage struct {
 }
 
 type IdentityMessage struct {
-	PeerId string `json:"peerId"`
-	Local  bool   `json:"local"`
+	PeerId      string `json:"peerId"`
+	Broadcaster bool   `json:"broadcaster"`
+	Subscriber  bool   `json:"subscriber"`
 }

--- a/server/view/index.html
+++ b/server/view/index.html
@@ -33,7 +33,7 @@
       send(JSON.stringify({
         event: 'identity',
         payload: {
-          local: false,
+          subscriber: true,
           peerId: {{ .clientId}}
         }
       }))


### PR DESCRIPTION
Other party can now listen on broadcaster events through CLI, not only web interface by just enabling listen mode `--listen` and providing peerId `--peer`

On this PR:

- Refactored identifying both ends, now they're  broadcaster and subscriber
- Subscriber can now listen to broadcaster events through CLI