### PR TITLE
Properly handle websocket closure and verify broadcaster ID

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -11,9 +11,16 @@ import (
 	"go.uber.org/zap"
 )
 
+type ControllerMessage struct {
+	Message    string
+	Error      error
+	Connection *websocket.Conn
+}
+
 var interrupt chan os.Signal
 var options *ClientOptions
 var clientId string
+var controller = make(chan int)
 
 func Main() {
 	options = InitOptions()
@@ -53,10 +60,13 @@ func Main() {
 
 	// Main CLI loop
 	for {
-		<-interrupt
-		zap.S().Info("Received SIGINT interrupt signal. Closing all pending connections")
-		HandleWebsocketClose(connection)
-		return
+		select {
+		case <-interrupt:
+			zap.S().Info("Received SIGINT interrupt signal. Closing all pending connections")
+			return
+		case <-controller:
+			return
+		}
 	}
 }
 

--- a/server/client.go
+++ b/server/client.go
@@ -32,11 +32,20 @@ type Client struct {
 	active      bool
 }
 
+func (client *Client) IsActiveBroadcaster() bool {
+	return client.broadcaster && client.active
+}
+
+func (client *Client) IsActiveSubscriber() bool {
+	return client.subscriber && client.active && client.peerId != ""
+}
+
 func (client *Client) ReadPump() {
 	defer func() {
 		zap.S().Info("Removing client")
 		client.hub.unregister <- client
 		zap.S().Info("Closing client connection")
+		// client.connection.WriteMessage(websocket.CloseMessage, []byte{})
 		client.connection.Close()
 	}()
 

--- a/server/client.go
+++ b/server/client.go
@@ -283,9 +283,7 @@ func HandleMessage(client *Client) (Message, error) {
 	err := client.connection.ReadJSON(&message)
 
 	if err != nil {
-		zap.L().Error("Error occurred while reading incoming JSON message", zap.Error(err))
-
-		if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
+		if websocket.IsCloseError(err, websocket.CloseAbnormalClosure, websocket.CloseGoingAway) {
 			zap.L().Warn("Unexpected websocket close, peer is disconnected, ignoring message...")
 		}
 

--- a/server/hub.go
+++ b/server/hub.go
@@ -77,6 +77,16 @@ func (h *Hub) Run() {
 			zap.S().Infow("Unregistering client",
 				"id", client.id)
 
+			// In case broadcaster is disconnecting, then disconnect subscribers too
+			if client.IsActiveBroadcaster() {
+				for _, c := range h.clients {
+					if c.IsActiveSubscriber() && c.peerId == client.id {
+						removeClient(c.hub, c.id, true)
+						// c.connection.WriteMessage(websocket.CloseMessage, []byte{})
+						// c.connection.Close()
+					}
+				}
+			}
 			removeClient(client.hub, client.id, true)
 
 		case message := <-h.broadcast:


### PR DESCRIPTION
- Close subscriber websocket connection when broadcaster socket is closed
- Validate `peerId` (broadcaster ID) in listen