### PR TITLE
Enable showing lines to stdout

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -22,8 +22,25 @@ var options *ClientOptions
 var clientId string
 var controller = make(chan int)
 
+func isStdin() bool {
+  stat, err := os.Stdin.Stat()
+
+  if err != nil {
+    fmt.Println("Couldn't check STDIN: ", err)
+    os.Exit(1)
+  }
+
+  return (stat.Mode() & os.ModeCharDevice) == 0
+}
+
 func Main() {
 	options = InitOptions()
+
+  if !options.Listen && !isStdin() {
+    fmt.Println("Nothing is being read, you should pipe something to stdin of this command")
+    return
+  }
+
 	interrupt = make(chan os.Signal) // Channel to listen for interrupt signal to gracefully terminate
 	input := make(chan string)
 

--- a/client/main.go
+++ b/client/main.go
@@ -134,6 +134,11 @@ func ScanFile(input chan string) {
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
 		text := scanner.Text()
+
+		if options.Output {
+			fmt.Println(text)
+		}
+
 		input <- text
 	}
 

--- a/client/options.go
+++ b/client/options.go
@@ -15,6 +15,7 @@ type ClientOptions struct {
 	LogLevel zapcore.Level
 	PeerId   string
 	Listen   bool
+	Output   bool
 }
 
 const (
@@ -29,6 +30,7 @@ var (
 	loglevel string
 	peer     string
 	listen   bool
+	output   bool
 )
 
 func fprintf(format string, a ...interface{}) {
@@ -48,6 +50,9 @@ func InitOptions() *ClientOptions {
 	flag.StringVar(&loglevel, "log", utils.WinningDefault(utils.GetEnvVariable("LOG_LEVEL"), loglevel, DEFAULT_LOG_LEVEL), "Log level")
 	flag.StringVar(&peer, "peer", "", "Peer client ID")
 	flag.BoolVar(&listen, "listen", false, "Initiate in listen mode to listen to peer")
+	flag.BoolVar(&listen, "l", false, "Initiate in listen mode to listen to peer")
+	flag.BoolVar(&output, "show-output", false, "Print output stream to stdout")
+	flag.BoolVar(&output, "o", false, "Print output stream to stdout")
 	flag.Parse()
 
 	return &ClientOptions{
@@ -56,5 +61,6 @@ func InitOptions() *ClientOptions {
 		LogLevel: utils.GetLogLevelFromString(loglevel),
 		PeerId:   peer,
 		Listen:   listen,
+		Output:   output,
 	}
 }


### PR DESCRIPTION
- Show stdin input file lines on stdout via `--show-output` or `-o` flag
- Check if something is piped to stdin, and fail otherwise