### PR TITLE
fix(server): use embed to load HTML files as HTML templates

### DIFF
--- a/internal/pkg/common/template.go
+++ b/internal/pkg/common/template.go
@@ -1,0 +1,21 @@
+package common
+
+import (
+	"html/template"
+
+	"github.com/gin-gonic/gin"
+)
+
+func LoadHtmlTemplates(server *gin.Engine, templates map[string]string) error {
+	for _, strTemplate := range templates {
+		tpl, err := template.New("index.html").Parse(strTemplate)
+
+		if err != nil {
+			return err
+		}
+
+		server.SetHTMLTemplate(tpl)
+	}
+
+	return nil
+}

--- a/server/http.go
+++ b/server/http.go
@@ -13,7 +13,7 @@ func InitHttpServer() {
 	zap.S().Debug("Initializing server routes")
 
 	server.GET("/", func(context *gin.Context) {
-		context.HTML(200, "index.html", nil)
+		context.HTML(200, HTML_MAIN_INDEX, nil)
 	})
 
 	server.GET("/ws", func(context *gin.Context) {
@@ -75,7 +75,7 @@ func SubscriberView(context *gin.Context) {
 
 	zap.S().Debugf("Client ID: [%s] was found on hub\n", clientId)
 
-	context.HTML(200, "index.html", gin.H{
+	context.HTML(200, HTML_MAIN_INDEX, gin.H{
 		"clientId": clientId,
 		"domain":   options.Domain.Websocket,
 	})

--- a/server/main.go
+++ b/server/main.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	_ "embed"
 	"fmt"
 
 	"github.com/gin-gonic/gin"
@@ -12,6 +13,12 @@ var (
 	options *ServerOptions
 	hub     *Hub
 	server  *gin.Engine
+	//go:embed view/index.html
+	mainHtmlView string
+)
+
+const (
+	HTML_MAIN_INDEX = "index.html"
 )
 
 func printOptions() {
@@ -60,13 +67,19 @@ func Main() {
 
 	zap.S().Debug("Loading server HTML files")
 
-	server.LoadHTMLFiles("./server/view/index.html")
+	err := common.LoadHtmlTemplates(server, map[string]string{
+		HTML_MAIN_INDEX: mainHtmlView,
+	})
+
+	if err != nil {
+		common.FatalError("Error while loading static HTML files", err)
+	}
 
 	InitHttpServer()
 
 	zap.S().Debugf("Running server on port [%d]\n", options.Port)
 
-	err := server.Run(fmt.Sprintf(":%d", options.Port))
+	err = server.Run(fmt.Sprintf(":%d", options.Port))
 
 	if err != nil {
 		common.FatalError("Error while running server", err)


### PR DESCRIPTION
- Use go embed to load static HTML templates into an HTML template
- Load each template into Gin using `SetHTMLTemplate`